### PR TITLE
improved print-tree

### DIFF
--- a/src/atom_finder/util/cdt_util.clj
+++ b/src/atom_finder/util/cdt_util.clj
@@ -49,6 +49,16 @@
      (conj
            (doseq [iast-node kids]
              (pre-tree f iast-node (inc index)))
+           ret)))
+  ([f node index tree-path]
+
+   (let [kids (children node)
+         kids-last-index (count kids)
+         ret (f node index tree-path)]
+
+     (conj
+           (doseq [[iast-node child-index] (map list kids (range 0 kids-last-index))]
+             (pre-tree f iast-node (inc index) (conj tree-path child-index)))
            ret))))
 
 (defn depth [node]

--- a/src/atom_finder/util/writer-util.clj
+++ b/src/atom_finder/util/writer-util.clj
@@ -6,21 +6,22 @@
 
 (defn print-tree [node]
   (letfn
-      [(f [node index]
+      [(f [node index tree-path]
          (let [offset (format " (offset: %s, %s)"
                               (-> node .getFileLocation .getNodeOffset)
                               (-> node .getFileLocation .getNodeLength))]
 
-           (printf "%s -%s %s -> %s\n"
+           (printf "%s -%s %s %s -> %s\n"
                    (apply str (repeat index "  "))
                    (-> node .getClass .getSimpleName)
+                   (str tree-path)
                    offset
                    (-> node .getRawSignature
                        (str "           ")
                        (.subSequence 0 10)
                        (.replaceAll "\n" " \\ ")))))]
 
-    (pre-tree f node)))
+    (pre-tree f node 1 [])))
 
 (def ast-writer (ASTWriter.))
 (defn write-ast [node] (.write ast-writer node))


### PR DESCRIPTION
You mentioned to leave in the original functionality. So I added the case for 3 arguments and say that only print-tree uses that 3 arguments.