### PR TITLE
Replace hardcoded Unix path separator with system-dependent separator

### DIFF
--- a/src/atom_finder/all_atoms_csv.clj
+++ b/src/atom_finder/all_atoms_csv.clj
@@ -8,10 +8,13 @@
    [clj-cdt.writer-util :refer :all]
   ))
 
+
+(def path-separator java.io.File/separator)
+
 (defn -main [& args]
   (println "atom,file,line,offset,code")
   (doseq [dir (map normalize-path args)]
-    (let [dir-len (inc (clojure.string/last-index-of dir "/"))]
+    (let [dir-len (inc (clojure.string/last-index-of dir path-separator))]
       (-<>> dir
             (pmap-dir-c-files #(all-atoms-in-tree atoms (parse-file %)))
             (apply concat)

--- a/src/atom_finder/atom_patch.clj
+++ b/src/atom_finder/atom_patch.clj
@@ -195,10 +195,10 @@
     ))
 
 ;(def filename "gcc-bugs-atoms_2017-03-28_200.edn")
-(def filename2 "gcc-bugs-atoms_2017-03-29.edn")
-(def gcc-bugs-atoms (->> filename2 read-data))
-(def gcc-bugs (->> gcc-bugs-atoms first (mapcat identity) (filter :revstr)))
-(->> gcc-bugs add-convenience-columns (write-res-csv "gcc-bugs_2017-03-29.csv"))
+;(def filename2 "gcc-bugs-atoms_2017-03-29.edn")
+;(def gcc-bugs-atoms (->> filename2 read-data))
+;(def gcc-bugs (->> gcc-bugs-atoms first (mapcat identity) (filter :revstr)))
+;(->> gcc-bugs add-convenience-columns (write-res-csv "gcc-bugs_2017-03-29.csv"))
 
 (defn add-convenience-columns
   [flat-res]


### PR DESCRIPTION
Replace hardcoded Unix path separator with system-dependent separator. Also commented out lines that caused the tests to fail, since they were looking for files which were not in the repository.

Tested on Windows and Linux.

The error was:

```
Caused by: java.lang.NullPointerException: Cannot invoke "Object.getClass()" because "x" is null
        at clojure.lang.Numbers.ops(Numbers.java:1013)
        at clojure.lang.Numbers.inc(Numbers.java:112)
        at atom_finder.all_atoms_csv$_main.invokeStatic(all_atoms_csv.clj:17)
        at atom_finder.all_atoms_csv$_main.doInvoke(all_atoms_csv.clj:14)
```